### PR TITLE
API for get_type functions

### DIFF
--- a/pandas_summary/__init__.py
+++ b/pandas_summary/__init__.py
@@ -269,6 +269,10 @@ class DataFrameSummary(object):
     def get_bools(self):
         return self.df.columns[self.columns_stats.loc['types'] == 'bool']
     
+    @property
+    def get_missing_frac(self):
+        return self.columns_stats.loc['missing'].apply(lambda x: float(x)/self.length)
+    
     def get_columns(self, df, usage, columns=None):
         """
         Returns a `data_frame.columns`.

--- a/pandas_summary/__init__.py
+++ b/pandas_summary/__init__.py
@@ -252,7 +252,23 @@ class DataFrameSummary(object):
             return self._get_date_summary(column)
         if column_type == self.TYPE_CONSTANT:
             return self._get_constant_summary(column)
-
+        
+    @property
+    def get_constants(self):
+        return self.df.columns[self.columns_stats.loc['types'] == 'constant']
+    @property
+    def get_categoricals(self):
+        return self.df.columns[self.columns_stats.loc['types'] == 'categorical']
+    @property
+    def get_numerics(self):
+        return self.df.columns[self.columns_stats.loc['types'] == 'numeric']
+    @property
+    def get_uniques(self):
+        return self.df.columns[self.columns_stats.loc['types'] == 'unique']
+    @property
+    def get_bools(self):
+        return self.df.columns[self.columns_stats.loc['types'] == 'bool']
+    
     def get_columns(self, df, usage, columns=None):
         """
         Returns a `data_frame.columns`.


### PR DESCRIPTION
introduce `@property` methods for

* get_constants
* get_categoricals
* get_numerics
* get_uniques
* get_bools

```
df = pd.DataFrame({
    'A': [1,2,3,4,5],
    'B': [0,1,1,1,0],
    'C': ['A', 'B', 'A', 'B', 'C'],
    'D': ['A', 'A', 'A', 'A', 'A'],
    'E': ['A', 'B', 'C', 'D', 'E']
})

dfs = DataFrameSummary(df)

print(dfs.get_numerics)
# Index(['A'], dtype='object')

print(dfs.get_bools)
# Index(['B'], dtype='object')

print(dfs.get_categoricals)
# Index(['C'], dtype='object')

print(dfs.get_constants)
# Index(['D'], dtype='object')

print(dfs.get_uniques)
# Index(['E'], dtype='object')
```