### PR TITLE
Add Mode to Numeric Statistic

### DIFF
--- a/pandas_summary/__init__.py
+++ b/pandas_summary/__init__.py
@@ -1,11 +1,11 @@
 from __future__ import division
-from six import string_types
 
 from collections import OrderedDict
 
 import numpy as np
 import pandas as pd
 from pandas.api import types
+from six import string_types
 
 
 class DataFrameSummary(object):
@@ -174,6 +174,7 @@ class DataFrameSummary(object):
         stats['variance'] = series.var()
         stats['min'] = series.min()
         stats['max'] = series.max()
+        stats['mode'] = series.mode()[0]
 
         for x in np.array([0.05, 0.25, 0.5, 0.75, 0.95]):
             stats[self._percent(x)] = series.quantile(x)

--- a/tests/test_dataframesummary.py
+++ b/tests/test_dataframesummary.py
@@ -1,7 +1,7 @@
 from __future__ import division
 
-from random import shuffle
 import unittest
+from random import shuffle
 
 import numpy as np
 import pandas as pd
@@ -171,7 +171,7 @@ class DataFrameSummaryTest(unittest.TestCase):
                              name='dbool1',
                              dtype=object).sort_index()
 
-        assert_series_equal(self.dfs['dbool1'].sort_index(), expected)
+        assert_series_equal(self.dfs['dbool1'], expected)
 
     def test_bool2_summary(self):
         count_values = self.df['dbool2'].value_counts()
@@ -217,13 +217,13 @@ class DataFrameSummaryTest(unittest.TestCase):
         num1 = self.df['dnumerics1']
         dm, dmp = self.dfs._get_deviation_of_mean(num1)
         dam, damp = self.dfs._get_median_absolute_deviation(num1)
-        expected = pd.Series(index=['mean', 'std', 'variance', 'min', 'max', '5%', '25%', '50%',
+        expected = pd.Series(index=['mean', 'std', 'variance', 'min', 'max', 'mode', '5%', '25%', '50%',
                                     '75%', '95%', 'iqr', 'kurtosis', 'skewness', 'sum', 'mad', 'cv',
                                     'zeros_num', 'zeros_perc', 'deviating_of_mean',
                                     'deviating_of_mean_perc', 'deviating_of_median',
                                     'deviating_of_median_perc', 'top_correlations', 'counts',
                                     'uniques', 'missing', 'missing_perc', 'types'],
-                             data=[num1.mean(), num1.std(), num1.var(), num1.min(), num1.max(),
+                             data=[num1.mean(), num1.std(), num1.var(), num1.min(), num1.max(), num1.mode()[0],
                                    num1.quantile(0.05), num1.quantile(
                                        0.25), num1.quantile(0.5),
                                    num1.quantile(0.75), num1.quantile(0.95),


### PR DESCRIPTION
This pull request is to add `mode` to the numeric statistic summary for columns as it is useful to know the most frequent value for some numeric columns, such as Age, Price, etc.

The Series implementation of `mode()` returns a series, hence the index reference - https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.mode.html#pandas.Series.mode 

Added `mode` to the testcase as well.

Also updated a testcase where the summary was getting re-sorted when it was already sorted. All test cases now pass.